### PR TITLE
Fixed path to main file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "Arun Israel <arun.israel@gmail.com>"
   ],
   "description": "An angular.js wrapper around the Google Places API",
-  "main": "google-places.js",
+  "main": "src/angularjs-google-places.js",
   "keywords": [
     "google places",
     "angular.js"


### PR DESCRIPTION
When using tools like grunt to auto-insert script tags, yours fails as the main path is incorrect based on your file structure. I've updated it to reflect what you have.
