### PR TITLE
Remove $rootScope.$apply(..) function wrappers for success and failure callbacks to Places API lookups.

### DIFF
--- a/src/angularjs-google-places.js
+++ b/src/angularjs-google-places.js
@@ -47,7 +47,7 @@ provider('ngGPlacesAPI', function () {
         return pResp;
     };
 
-    this.$get = function ($rootScope, $q, gMaps, gPlaces, $window) {
+    this.$get = function ($q, gMaps, gPlaces, $window) {
 
         function commonAPI(args) {
             var req = angular.copy(defaults, {});
@@ -57,13 +57,9 @@ provider('ngGPlacesAPI', function () {
 
             function callback(results, status) {
                 if (status == gPlaces.PlacesServiceStatus.OK) {
-                    $rootScope.$apply(function () {
-                        return deferred.resolve(req._parser(results));
-                    });
+                  return deferred.resolve(req._parser(results));
                 } else {
-                    $rootScope.$apply(function () {
-                        deferred.reject(req._errorMsg);
-                    });
+                  deferred.reject(req._errorMsg);
                 }
             }
             if (req._genLocation) {
@@ -101,7 +97,7 @@ provider('ngGPlacesAPI', function () {
         };
     };
 
-    this.$get.$inject = ['$rootScope', '$q', 'gMaps', 'gPlaces', '$window'];
+    this.$get.$inject = ['$q', 'gMaps', 'gPlaces', '$window'];
 
     this.setDefaults = function (args) {
         angular.extend(defaults, args);


### PR DESCRIPTION
There shouldn't be a need by default to include `$rootScope.$apply()` calls when wrapping the **success** and **failure** callbacks for the Places API calls.  This causes problem when nesting them with a basic lookup then a detailed lookup.

Here are examples with _angular-1.2.6_

Example with `$rootScope.apply(...)` error:
http://plnkr.co/edit/cVp5rh?p=preview

Updated `angularjs-google-places.js` with no error:
http://plnkr.co/edit/nHkXmC?p=preview
